### PR TITLE
BTFS-1179 add start and start_dev in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ start_dev:
 	iptb run -- btfs config Services.EscrowDomain 'https://escrow-dev.btfs.io'
 	iptb run -- btfs config Services.GuardDomain 'https://guard-dev.btfs.io'
 	iptb run -- btfs config Services.HubDomain 'https://hub-dev.btfs.io'
+	iptb run -- btfs config optin
 	iptb start
 
 stop:

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,41 @@
 IPTB_ROOT ?=$(HOME)/testbed
+NODES ?=5
 
 all: iptb
 
 deps:
-	gx install
+	go mod download
 
 iptb: deps
-	gx-go rw
 	(cd iptb; go build)
-	gx-go uw
 CLEAN += iptb/iptb
 
-ipfslocal: deps
-	gx-go rw
-	(cd local/plugin; go build -buildmode=plugin -o ../../build/localipfs.so)
-	gx-go uw
-CLEAN += build/localipfs.so
-
-p2pdlocal: deps
-	gx-go rw
-	(cd localp2pd/plugin; go build -buildmode=plugin -o ../../build/localp2pd.so)
-	gx-go uw
-CLEAN += build/localp2pd.so
-
-ipfsdocker: deps
-	gx-go rw
-	(cd docker/plugin; go build -buildmode=plugin -o ../../build/dockeripfs.so)
-	gx-go uw
-CLEAN += build/dockeripfs.so
-
-ipfsbrowser:
-	gx-go rw
-	(cd browser/plugin; go build -buildmode=plugin -o ../../build/browseripfs.so)
-	gx-go uw
-CLEAN += build/browseripfs.so
+btfslocal: deps
+	(cd localbtfs/plugin; go build -buildmode=plugin -o ../../build/localbtfs.so)
+CLEAN += build/localbtfs.so
 
 install: deps
-	gx-go rw
 	(cd iptb; go install)
-	gx-go uw
 
 clean:
 	rm ${CLEAN}
 
-.PHONY: all clean ipfslocal p2pdlocal ipfsdocker ipfsbrowser
+start:
+	iptb auto -type localbtfs -count $(NODES)
+	iptb run -- btfs config --json Addresses.Announce  []
+	iptb start
+
+start_dev:
+	iptb auto -type localbtfs -count $(NODES)
+	iptb run -- btfs config --json Addresses.Announce  []
+	iptb run -- btfs config Services.StatusServerDomain 'https://status-dev.btfs.io'
+	iptb run -- btfs config Services.EscrowDomain 'https://escrow-dev.btfs.io'
+	iptb run -- btfs config Services.GuardDomain 'https://guard-dev.btfs.io'
+	iptb run -- btfs config Services.HubDomain 'https://hub-dev.btfs.io'
+	iptb start
+
+stop:
+	iptb stop
+
+
+.PHONY: all clean ipfslocal p2pdlocal ipfsdocker ipfsbrowser start start_dev stop

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ GLOBAL OPTIONS:
 
 ```
 $ git clone git@github.com:TRON-US/iptb-btfs-plugins.git
+$ cd iptb-btfs-plugins
 $ make install 
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,23 @@ GLOBAL OPTIONS:
 ### Install
 
 ```
-$ go get -d github.com/TRON-US/iptb-btfs-plugins
-$ cd $GOPATH/src/github.com/TRON-US/iptb-btfs-plugins
-$ cd iptb
-$ go install
+$ git clone git@github.com:TRON-US/iptb-btfs-plugins.git
+$ make install 
 ```
 
+### Run iptb with btfs nodes
+```
+$ export NODES=<number of btfs nodes desired, default is 5>
+$ make start
+```
+
+### Run iptb with btfs nodes reporting to dev services
+```
+$ export NODES=<number of btfs nodes desired, default is 5>
+$ make start_dev
+```
 
 ### Configure for local networking
-
 ```
 $ iptb run -- btfs config --json Addresses.Announce  []
 $ iptb stop

--- a/localbtfs/localbtfs.go
+++ b/localbtfs/localbtfs.go
@@ -122,18 +122,11 @@ func (l *LocalIpfs) Init(ctx context.Context, agrs ...string) (testbedi.Output, 
 	agrs = append([]string{l.binary, "init"}, agrs...)
 	output, oerr := l.RunCmd(ctx, nil, agrs...)
 
-	fmt.Println("in Init args is ", agrs)
-	fmt.Println("in Init output is: ", output)
-	fmt.Println("in Init oerr is: ", oerr)
-
 	if oerr != nil {
 		return nil, oerr
 	}
 
 	icfg, err := l.Config()
-
-	fmt.Println("in Init icfg is: ", icfg)
-	fmt.Println("in Init err is: ", err)
 
 	if err != nil {
 		return nil, err
@@ -168,7 +161,6 @@ func (l *LocalIpfs) Start(ctx context.Context, wait bool, args ...string) (testb
 	dir := l.dir
 	dargs := append([]string{"daemon"}, args...)
 
-	fmt.Println("in Start, dargs is: ", dargs)
 
 	cmd := exec.Command(l.binary, dargs...)
 	cmd.Dir = dir
@@ -279,21 +271,18 @@ func (l *LocalIpfs) RunCmd(ctx context.Context, stdin io.Reader, args ...string)
 	}
 
 	err = cmd.Start()
-	fmt.Println("in RunCmd past the cmd.Start() err is: ", err)
 
 	if err != nil {
 		return nil, err
 	}
 
 	stderrbytes, err := ioutil.ReadAll(stderr)
-	fmt.Println("in RunCmd past the ioutil.ReadAll() err is: ", err)
 
 	if err != nil {
 		return nil, err
 	}
 
 	stdoutbytes, err := ioutil.ReadAll(stdout)
-	fmt.Println("in RunCmd past the ioutil.ReadAll() err is: ", err)
 
 	if err != nil {
 		return nil, err
@@ -304,7 +293,6 @@ func (l *LocalIpfs) RunCmd(ctx context.Context, stdin io.Reader, args ...string)
 	}
 
 	exiterr := cmd.Wait()
-	fmt.Println("in RunCmd past the cmd.Wait() err is: ", exiterr)
 
 	var exitcode = 0
 	switch oerr := exiterr.(type) {
@@ -357,7 +345,6 @@ func (l *LocalIpfs) Shell(ctx context.Context, nodes []testbedi.Core) error {
 	}
 
 	nenvs, err := l.env()
-	fmt.Println("in Shell past the l.env) nenvs is: ", nenvs)
 
 	if err != nil {
 		return err
@@ -369,7 +356,6 @@ func (l *LocalIpfs) Shell(ctx context.Context, nodes []testbedi.Core) error {
 
 	for i, n := range nodes {
 		peerid, err := n.PeerID()
-		fmt.Println("in Shell in for range nodes loop, peerid: ", peerid)
 
 
 		if err != nil {
@@ -377,7 +363,6 @@ func (l *LocalIpfs) Shell(ctx context.Context, nodes []testbedi.Core) error {
 		}
 
 		nenvs = append(nenvs, fmt.Sprintf("NODE%d=%s", i, peerid))
-		fmt.Println("in Shell in for range nodes loop, after append, nenvs: ", nenvs)
 
 	}
 

--- a/util.go
+++ b/util.go
@@ -75,14 +75,8 @@ func GetPeerID(l testbedi.Config) (*cid.Cid, error) {
 	if !ok {
 		return nil, fmt.Errorf("Error: GetConfig() is not an btfs config")
 	}
-	fmt.Println("in util.go GetPeerID(), lcfg is: ", lcfg)
-	fmt.Println("============================")
-	fmt.Printf("%+v\n",lcfg)
 
 	pcid, err := cid.Decode(lcfg.Identity.PeerID)
-
-	fmt.Println("in util.go GetPeerID(), pcid is: ", pcid)
-	fmt.Println("in util.go GetPeerID(), err is: ", err)
 
 	if err != nil {
 		return nil, err
@@ -103,15 +97,9 @@ func GetPeerID_btfs(l testbedi.Config) (string, error) {
 	if !ok {
 		return "Error", fmt.Errorf("Error: GetConfig() is not an btfs config")
 	}
-	fmt.Println("in util.go GetPeerID_btfgs(), lcfg is: ", lcfg)
-	fmt.Println("============================")
-	fmt.Printf("%+v\n",lcfg)
 
 	//pcid, err := cid.Decode(lcfg.Identity.PeerID)
 	pcid := lcfg.Identity.PeerID
-
-	fmt.Println("in util.go GetPeerID_btfs(), pcid is: ", pcid)
-
 
 	return pcid, nil
 }


### PR DESCRIPTION
add new `make start` and `make start_dev` to make it easy to start up iptb with btfs nodes and documented in README.
revised the `make install` to run without gx.
