### PR TITLE
BTFS-1253 allow external connections and write back swarm port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 start:
 	iptb auto -type localbtfs -count $(NODES)
-	iptb run -- btfs config --json Addresses.Announce  []
+#	iptb run -- btfs config --json Addresses.Announce  []
 ifdef GUARDPUBKEYS
 	iptb run -- btfs config --json Services.GuardPubKeys ['"$(GUARDPUBKEYS)"']
 endif
@@ -41,7 +41,7 @@ endif
 
 start_dev:
 	iptb auto -type localbtfs -count $(NODES)
-	iptb run -- btfs config --json Addresses.Announce  []
+#	iptb run -- btfs config --json Addresses.Announce  []
 	iptb run -- btfs config Services.StatusServerDomain 'https://status-dev.btfs.io'
 	iptb run -- btfs config Services.EscrowDomain 'https://escrow-dev.btfs.io'
 	iptb run -- btfs config Services.GuardDomain 'https://guard-dev.btfs.io'

--- a/standalone/rewrite_config.go
+++ b/standalone/rewrite_config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -45,6 +46,10 @@ func main() {
 				parts := strings.Split(lines[j], "/")
 				if len(parts) > 0 {
 					swarm_port = parts[(len(parts))-1]
+					_, err := strconv.Atoi(swarm_port)
+					if err != nil {
+						panic("The Swarm port cannot be read")
+					}
 					fmt.Println("swarm port is: ", swarm_port, " for node: ", i)
 				} else {
 					fmt.Println("Unable to parse Swarm port")
@@ -55,6 +60,10 @@ func main() {
 				parts := strings.Split(lines[j], "/")
 				if len(parts) > 0 {
 					api_port = parts[(len(parts))-1]
+					_, err := strconv.Atoi(api_port)
+					if err != nil {
+						panic("The API port cannot be read")
+					}
 					fmt.Println("api server port is: ", api_port, " for node: ", i)
 				} else {
 					fmt.Println("Unable to parse API port")
@@ -65,6 +74,10 @@ func main() {
 				parts := strings.Split(lines[j], "/")
 				if len(parts) > 0 {
 					remote_api_port = parts[(len(parts))-1]
+					_, err := strconv.Atoi(remote_api_port)
+					if err != nil {
+						panic("The Remote API port cannot be read")
+					}
 					fmt.Println("remote api server port is: ", remote_api_port, " for node: ", i)
 				} else {
 					fmt.Println("Unable to parse Remote API port")

--- a/standalone/rewrite_config.go
+++ b/standalone/rewrite_config.go
@@ -43,20 +43,32 @@ func main() {
 			if strings.HasPrefix(lines[j], "Swarm listening on /ip4/") {
 				//split to find port value
 				parts := strings.Split(lines[j], "/")
-				swarm_port = parts[(len(parts))-1]
-				fmt.Println("swarm port is: ", swarm_port, " for node: ", i)
+				if len(parts) > 0 {
+					swarm_port = parts[(len(parts))-1]
+					fmt.Println("swarm port is: ", swarm_port, " for node: ", i)
+				} else {
+					fmt.Println("Unable to parse Swarm port")
+				}
 			}
 			if strings.HasPrefix(lines[j], "API server listening") {
 				//split to find port value
 				parts := strings.Split(lines[j], "/")
-				api_port = parts[(len(parts))-1]
-				fmt.Println("api server port is: ", api_port, " for node: ", i)
+				if len(parts) > 0 {
+					api_port = parts[(len(parts))-1]
+					fmt.Println("api server port is: ", api_port, " for node: ", i)
+				} else {
+					fmt.Println("Unable to parse API port")
+				}
 			}
 			if strings.HasPrefix(lines[j], "Remote API server listening") {
 				//split to find port value
 				parts := strings.Split(lines[j], "/")
-				remote_api_port = parts[(len(parts))-1]
-				fmt.Println("remote api server port is: ", remote_api_port, " for node: ", i)
+				if len(parts) > 0 {
+					remote_api_port = parts[(len(parts))-1]
+					fmt.Println("remote api server port is: ", remote_api_port, " for node: ", i)
+				} else {
+					fmt.Println("Unable to parse Remote API port")
+				}
 			}
 		}
 

--- a/standalone/rewrite_config.go
+++ b/standalone/rewrite_config.go
@@ -45,11 +45,7 @@ func main() {
 				//split to find port value
 				parts := strings.Split(lines[j], "/")
 				if len(parts) > 0 {
-					swarm_port = parts[(len(parts))-1]
-					_, err := strconv.Atoi(swarm_port)
-					if err != nil {
-						panic("The Swarm port cannot be read")
-					}
+					swarm_port = parsePort(parts[len(parts)-1])
 					fmt.Println("swarm port is: ", swarm_port, " for node: ", i)
 				} else {
 					fmt.Println("Unable to parse Swarm port")
@@ -59,11 +55,7 @@ func main() {
 				//split to find port value
 				parts := strings.Split(lines[j], "/")
 				if len(parts) > 0 {
-					api_port = parts[(len(parts))-1]
-					_, err := strconv.Atoi(api_port)
-					if err != nil {
-						panic("The API port cannot be read")
-					}
+					api_port = parsePort(parts[len(parts)-1])
 					fmt.Println("api server port is: ", api_port, " for node: ", i)
 				} else {
 					fmt.Println("Unable to parse API port")
@@ -73,11 +65,7 @@ func main() {
 				//split to find port value
 				parts := strings.Split(lines[j], "/")
 				if len(parts) > 0 {
-					remote_api_port = parts[(len(parts))-1]
-					_, err := strconv.Atoi(remote_api_port)
-					if err != nil {
-						panic("The Remote API port cannot be read")
-					}
+					remote_api_port = parsePort(parts[len(parts)-1])
 					fmt.Println("remote api server port is: ", remote_api_port, " for node: ", i)
 				} else {
 					fmt.Println("Unable to parse Remote API port")
@@ -125,4 +113,12 @@ func main() {
 		}
 	}
 
+}
+
+func parsePort(port string) string {
+	_, err := strconv.Atoi(port)
+	if err != nil {
+		panic("The port value cannot be read")
+	}
+	return port
 }

--- a/util.go
+++ b/util.go
@@ -153,7 +153,7 @@ func ReadLogs(l testbedi.Libp2p) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/log/tail", ip, pt))
+	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v1/log/tail", ip, pt))
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func GetBW(l testbedi.Libp2p) (*BW, error) {
 		return nil, err
 	}
 
-	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/stats/bw", ip, pt))
+	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v1/stats/bw", ip, pt))
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func tryAPICheck(l testbedi.Libp2p) error {
 		return err
 	}
 
-	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/id", ip, pt))
+	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v1/id", ip, pt))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
by default lets allow external connections to the iptb btfs testbed.  also save the swarm port so it does not change after a stop/start of iptb.