### PR TITLE
BTFS-1262 add makefile entry start_testnet and api listen locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,17 @@ start_dev:
 	iptb logs > iptb_logs.txt
 	go run standalone/rewrite_config.go
 
+start_testnet:
+	iptb auto -type localbtfs -count $(NODES)
+	iptb run -- btfs config profile apply storage-host-testnet
+	iptb run -- btfs config optin
+	iptb start
+	sleep 10
+	iptb logs > iptb_logs.txt
+	go run standalone/rewrite_config.go
+
 stop:
 	iptb stop
 
 
-.PHONY: all clean ipfslocal p2pdlocal ipfsdocker ipfsbrowser start start_dev stop
+.PHONY: all clean ipfslocal p2pdlocal ipfsdocker ipfsbrowser start start_dev start_testnet stop

--- a/standalone/rewrite_config.go
+++ b/standalone/rewrite_config.go
@@ -91,8 +91,8 @@ func main() {
 		path := home_path + "/testbed/testbeds/default/" + local_node_id + "/config"
 
 		//allow connections from external nodes
-		new_api_string := `    "API": "/ip4/0.0.0.0/tcp/` + nodePorts[i].api + `",`
-		new_remote_api_string := `    "RemoteAPI": "/ip4/0.0.0.0/tcp/` + nodePorts[i].remote_api + `",`
+		new_api_string := `    "API": "/ip4/127.0.0.1/tcp/` + nodePorts[i].api + `",`
+		new_remote_api_string := `    "RemoteAPI": "/ip4/127.0.0.1/tcp/` + nodePorts[i].remote_api + `",`
 		new_swarm_string := `      "/ip4/0.0.0.0/tcp/` + nodePorts[i].swarm + `"`
 		new_announce_string := `tcp/` + nodePorts[i].swarm
 

--- a/standalone/rewrite_config.go
+++ b/standalone/rewrite_config.go
@@ -90,7 +90,6 @@ func main() {
 		home_path := os.Getenv("HOME")
 		path := home_path + "/testbed/testbeds/default/" + local_node_id + "/config"
 
-		//allow connections from external nodes
 		new_api_string := `    "API": "/ip4/127.0.0.1/tcp/` + nodePorts[i].api + `",`
 		new_remote_api_string := `    "RemoteAPI": "/ip4/127.0.0.1/tcp/` + nodePorts[i].remote_api + `",`
 		new_swarm_string := `      "/ip4/0.0.0.0/tcp/` + nodePorts[i].swarm + `"`


### PR DESCRIPTION
- added a new recipe to set the iptb btfs nodes to load storage-host-testnet profile `make start_testnet` 
- changed api and report api ports to listen locally.